### PR TITLE
Error accumulator

### DIFF
--- a/Liquid.NET.Tests/Constants/LiquidValueTests.cs
+++ b/Liquid.NET.Tests/Constants/LiquidValueTests.cs
@@ -43,63 +43,19 @@ namespace Liquid.NET.Tests.Constants
 
         }
 
+        [Test]
+        public void ToOption_Should_Convert_To_Some()
+        {
+            // Arrange
+            var str = LiquidString.Create("test");
 
-//        [Test]
-//        public void It_Should_Chain_A_Function()
-//        {
-//            // Arrange
-//            var var1 = new LiquidNumeric(123);
-//            var var2 = new LiquidNumeric(100);
-//
-//            // Act
-//            //var result = var1.Bind(x => Add(x, var2));
-//            
-//            var result = var1.Bind(x => new LiquidNumeric((decimal)var2.Value + (decimal) x.Value));
-//            //var result= fn(var2);
-//            // Assert
-//            Assert.That(result.Value, Is.EqualTo(223m));
-//
-//        }
+            // Act
+            var option = str.ToOption();
 
-//        [Test]
-//        public void It_Should_Pass_An_Error_Back()
-//        {
-//            // Arrange
-//            var var1 = new LiquidNumeric(123);
-//            var var2 = new LiquidNumeric(100);
-//
-//            // Act
-//            var result = var1.Bind(x => new LiquidNumeric((decimal)var2.Value + (decimal) x.Value));
-//            var result2 = result.Bind(x =>
-//            {
-//                var y = new LiquidNumeric(0) { ErrorMessage = "An error has occurred" };
-//                return y;
-//            });
-//            //var result= fn(var2);
-//            // Assert
-//            Logger.Log(result2);
-//            Assert.That(result2.HasError, Is.True);
-//
-//        }
+            // Assert
+            Assert.That(option.Value, Is.EqualTo(LiquidString.Create("test")));
 
-//        [Test]
-//        public void It_Should_Return_Error_If_Passed_Unknown()
-//        {
-//            // Arrange
-//            var undefinedNumber = ConstantFactory.CreateNilValueOfType<LiquidNumeric>("Undefined test");
-//                  
-//            // Act
-//            var result = undefinedNumber.Bind(x => _testToString((LiquidNumeric) x));
-//
-//            // Assert
-//            Assert.That(result.IsUndefined, Is.True);
-//
-//        }
-
-          //private Func<LiquidNumeric, LiquidNumeric, LiquidNumeric> Add = (x, y) => new LiquidNumeric((decimal)x.Value + (Decimal)y.Value);
-
-          //private readonly Func<LiquidNumeric, LiquidString> _testToString = num => LiquidString.Create(num.Value.ToString());
-
+        }
 
     }
 }

--- a/Liquid.NET.Tests/Constants/MissingValueTests.cs
+++ b/Liquid.NET.Tests/Constants/MissingValueTests.cs
@@ -27,7 +27,7 @@ namespace Liquid.NET.Tests.Constants
            
             // Act
             var result = RenderingHelper.RenderTemplate("Result : {{ "+varname+" }}", ctx);
-
+            Console.WriteLine(result);
             // Assert
             Assert.That(result, Is.EqualTo("Result : ERROR: " + missingVar + " is undefined"));
 

--- a/Liquid.NET.Tests/Filters/DefaultFilterTests.cs
+++ b/Liquid.NET.Tests/Filters/DefaultFilterTests.cs
@@ -65,6 +65,21 @@ namespace Liquid.NET.Tests.Filters
         }
 
         [Test]
+        public void It_Should_Not_Return_Default_If_Array_Has_Elements()
+        {
+            // Arrange
+            TemplateContext ctx = new TemplateContext();
+
+            // Act
+            var result = RenderingHelper.RenderTemplate("Result : {% assign arr=\"1|2\" | split: \"|\"%}{{ arr | default: \"DEFAULT\" }}", ctx);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("Result : 12"));
+        }
+
+
+
+        [Test]
         public void It_Should_Return_Default_If_Array_Is_Null()
         {
             // Arrange

--- a/Liquid.NET.Tests/LiquidASTRendererTests.cs
+++ b/Liquid.NET.Tests/LiquidASTRendererTests.cs
@@ -517,14 +517,22 @@ namespace Liquid.NET.Tests
 
         }
 
-        private static string Render(ITemplateContext templateContext, LiquidAST liquidAst)
+        private static string Render(ITemplateContext templateContext, LiquidAST liquidAst, Action<LiquidError> onError = null)
         {
+            if (onError == null)
+            {
+                onError = error => { };
+            }
             String result = "";
             var renderingVisitor = new RenderingVisitor(templateContext);
             renderingVisitor.StartWalking(liquidAst.RootNode, str => result += str);
             if (renderingVisitor.HasErrors)
             {
-                throw new LiquidRendererException(renderingVisitor.Errors);
+                foreach (var error in renderingVisitor.Errors)
+                {
+                    onError(error);
+                }
+                //throw new LiquidRendererException(renderingVisitor.Errors);
             }
             return result;
         }

--- a/Liquid.NET.Tests/Parser/ErrorTests.cs
+++ b/Liquid.NET.Tests/Parser/ErrorTests.cs
@@ -9,27 +9,19 @@ namespace Liquid.NET.Tests.Parser
     public class ErrorTests
     {
         [Test]
-        [TestCase(@"TEST: {{ ""test,test"" | split: }} DONE", @"Liquid error: missing arguments after colon in filter 'split'")]
+        [TestCase(@"TEST: {{ ""test,test"" | split: }} DONE",
+            @"Liquid error: missing arguments after colon in filter 'split'")]
         public void It_Should_Handle_Invalid_Filters(String input, String expected)
         {
-            // Arrange
-            try
-            {
-                ITemplateContext ctx = new TemplateContext().WithAllFilters();
-                IList<LiquidError> errors = new List<LiquidError>();
-                var template = CreateRenderer(errors, input);
 
-                // Act
-                template.Render(ctx);
-            }
-            catch (LiquidParserException ex)
-            {
-                // Assert
-                //var allErrs = String.Join(",", ex.LiquidErrors.Select(x => x.ToString()));
-                var err = ex.LiquidErrors.FirstOrDefault(x => x.ToString().Contains(expected));
-                Assert.That(err, Is.Not.Null);
-            }
+            ITemplateContext ctx = new TemplateContext().WithAllFilters();
+            IList<LiquidError> errors = new List<LiquidError>();
+            var template = CreateRenderer(errors, input);
 
+            // Act
+            template.Render(ctx);
+            var err = errors.FirstOrDefault(x => x.ToString().Contains(expected));
+            Assert.That(err, Is.Not.Null);
 
         }
 
@@ -38,20 +30,11 @@ namespace Liquid.NET.Tests.Parser
         {
             // Arrange
             const string erroneousTemplate = "{{";
-            //ITemplateContext ctx = new TemplateContext().WithAllFilters();
             IList<LiquidError> errors = new List<LiquidError>();            
             
             // Act
-            try
-            {
-                CreateRenderer(errors, erroneousTemplate);
-                Assert.Fail("It Should throw an exception.");
-            }
-            catch (LiquidParserException ex)
-            {
-                Assert.That(ex.LiquidErrors.Count, Is.EqualTo(1));
-            }
-
+            CreateRenderer(errors, erroneousTemplate);
+            Assert.That(errors.Count, Is.EqualTo(1));
         }
 
 
@@ -74,10 +57,10 @@ namespace Liquid.NET.Tests.Parser
         private static LiquidTemplate CreateRenderer(IList<LiquidError> errors, string erroneousTemplate)
         {
             var liquidAstGenerator = new LiquidASTGenerator();
-            OnParsingErrorEventHandler liquidAstGeneratorParsingErrorEventHandler = errors.Add;
+            //OnParsingErrorEventHandler liquidAstGeneratorParsingErrorEventHandler = errors.Add;
 
-            liquidAstGenerator.ParsingErrorEventHandler += liquidAstGeneratorParsingErrorEventHandler;
-            var liquidAst = liquidAstGenerator.Generate(erroneousTemplate);
+            //liquidAstGenerator.ParsingErrorEventHandler += liquidAstGeneratorParsingErrorEventHandler;
+            var liquidAst = liquidAstGenerator.Generate(erroneousTemplate, errors.Add);
 
             var template = new LiquidTemplate(liquidAst);
             return template;

--- a/Liquid.NET.Tests/RenderingHelper.cs
+++ b/Liquid.NET.Tests/RenderingHelper.cs
@@ -1,8 +1,13 @@
-﻿namespace Liquid.NET.Tests
+﻿using System;
+
+namespace Liquid.NET.Tests
 {
     public static class RenderingHelper
     {
-        public static string RenderTemplate(string resultHello, ITemplateContext ctx = null)
+        public static string RenderTemplate(
+            string resultHello, 
+            ITemplateContext ctx = null,
+            Action<LiquidError> onRenderingError = null)
         {
             if (ctx == null)
             {
@@ -10,7 +15,8 @@
             }
             ctx.WithAllFilters();
             var template = LiquidTemplate.Create(resultHello);
-            return template.Render(ctx);
+            return template.Render(ctx, onRenderingError);
+            
         }
     }
 }

--- a/Liquid.NET.Tests/Ruby/ErrorTests.cs
+++ b/Liquid.NET.Tests/Ruby/ErrorTests.cs
@@ -60,26 +60,16 @@ namespace Liquid.NET.Tests.Ruby
 
         [Test]
         [TestCase(@"{% unknown_tag %}", @"Liquid syntax error: Unknown tag 'unknown_tag'")]
-        public void It_Should_Generate_An_Exception(String input, String expectedMessage) {
+        public void It_Should_Capture_An_Error(String input, String expectedMessage) {
 
             // Arrange
             ITemplateContext ctx = new TemplateContext().WithAllFilters();
+            List<LiquidError> errors = new List<LiquidError>();
 
-            try
-            {
-                var result = RenderingHelper.RenderTemplate(input);
-                Assert.Fail("Expected exception: "+expectedMessage);
-            }
-            catch (LiquidParserException ex)
-            {
-                // Assert
-                Assert.That(ex.LiquidErrors[0].ToString(), Is.StringContaining(expectedMessage));
-            }
-            catch (LiquidRendererException ex)
-            {
-                // Assert
-                Assert.That(ex.LiquidErrors[0].ToString(), Is.StringContaining(expectedMessage));
-            }
+            var result = RenderingHelper.RenderTemplate(input, onRenderingError: err => errors.Add(err));
+
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ToString(), Is.StringContaining(expectedMessage));
         }
         
     }

--- a/Liquid.NET.Tests/Ruby/LiquidTests.cs
+++ b/Liquid.NET.Tests/Ruby/LiquidTests.cs
@@ -548,21 +548,26 @@ c")]
                 ctx.DefineLocalVariable(tuple.Item1, tuple.Item2);
             }
             var template = LiquidTemplate.Create(input);
+            IList<LiquidError> errors = new List<LiquidError>();
             try
             {
-                String result = template.Render(ctx);
-                Assert.Fail("Expected exception: " + expectedMessage);
+                String result = template.Render(ctx, onRenderingError: errors.Add);
+                //Console.WriteLine("Errors")
+                Assert.That(errors.Count, Is.EqualTo(1));
+                Assert.That(errors[0].ToString(), Is.StringContaining(expectedMessage));
+                //Assert.Fail("Expected exception: " + expectedMessage);
             }
             catch (LiquidParserException ex)
             {
                 // Assert
                 Assert.That(ex.LiquidErrors[0].ToString(), Is.StringContaining(expectedMessage));
             }
-            catch (LiquidRendererException ex)
-            {
+            //catch (LiquidRendererException ex)
+            //{
                 // Assert
-                Assert.That(ex.LiquidErrors[0].ToString(), Is.StringContaining(expectedMessage));
-            }
+                //Assert.That(ex.LiquidErrors[0].ToString(), Is.StringContaining(expectedMessage));
+              //  Assert.That(errors.ToString(), Is.StringContaining(expectedMessage));
+            //}
         }
 
     }

--- a/Liquid.NET.Tests/Tags/CaptureBlockTagTests.cs
+++ b/Liquid.NET.Tests/Tags/CaptureBlockTagTests.cs
@@ -33,19 +33,19 @@ namespace Liquid.NET.Tests.Tags
             var template = LiquidTemplate.Create("Result : {% for item in array %}{% capture thecycle %}{% cycle 'odd', 'even' %}{% endcapture %}{{ thecycle }} {% endfor %}");
 
             // Act
-            try
-            {
+//            try
+//            {
                 String result = template.Render(ctx);
                 Logger.Log(result);
 
                 // Assert
                 Assert.That(result.TrimEnd(), Is.EqualTo("Result : odd even odd even"));
-            }
-            catch (LiquidRendererException ex)
-            {
-                Logger.Log(ex.Message);
-                throw;
-            }
+//            }
+//            catch (LiquidRendererException ex)
+//            {
+//                Logger.Log(ex.Message);
+//                throw;
+//            }
 
         }
 

--- a/Liquid.NET.Tests/Tags/CustomBlockTagTests.cs
+++ b/Liquid.NET.Tests/Tags/CustomBlockTagTests.cs
@@ -83,20 +83,23 @@ namespace Liquid.NET.Tests.Tags
         [Test]
         public void It_Should_Show_Error_On_Missing_Tags()
         {
-            // Act
-            //try
-            //{
+            IList<LiquidError> errors = new List<LiquidError>();
+            RenderingHelper.RenderTemplate("Result : {% test %}", onRenderingError: errors.Add);
+
+            Assert.That(String.Join(",",errors.Select(x => x.Message)), Is.EqualTo("Liquid syntax error: Unknown tag 'test'"));
+
+        }
+
+        [Test]
+        public void It_Should_Show_Error_On_Missing_BLocks()
+        {
             IList<LiquidError> errors = new List<LiquidError>();
             RenderingHelper.RenderTemplate("Result : {% test %}{% endtest %}", onRenderingError: errors.Add);
 
-            //Assert.Fail("THis should have thrown an error");
-            //}
-            //catch (LiquidRendererException ex)
-            //{
-                // Assert
-                Assert.That(String.Join(",",errors.Select(x => x.Message)), Is.EqualTo("Liquid syntax error: Unknown tag 'test'"));
-            //}
+            Assert.That(String.Join(",", errors.Select(x => x.Message)), Is.EqualTo("Liquid syntax error: Unknown tag 'test'"));
+
         }
+
 
         [Test]
         public void It_Should_Parse_A_Custom_BlockTag_Along_With_A_Custom_Tag() 

--- a/Liquid.NET.Tests/Tags/CustomBlockTagTests.cs
+++ b/Liquid.NET.Tests/Tags/CustomBlockTagTests.cs
@@ -16,8 +16,8 @@ namespace Liquid.NET.Tests.Tags
         [Test]
         public void It_Should_Parse_A_Custom_BlockTag()
         {
-            try
-            {
+//            try
+//            {
                 // Act
                 var templateContext =
                     new TemplateContext().WithAllFilters().WithCustomTagBlockRenderer<WordReverserBlockTag>("echoargs");
@@ -29,11 +29,11 @@ namespace Liquid.NET.Tests.Tags
 
                 // Assert
                 Assert.That(result, Is.EqualTo("Result : ohce"));
-            }
-            catch (LiquidRendererException ex)
-            {
-                Assert.Fail(String.Join(",", ex.LiquidErrors.Select(x => x.Message)));
-            }
+//            }
+//            catch (LiquidRendererException ex)
+//            {
+//                Assert.Fail(String.Join(",", ex.LiquidErrors.Select(x => x.Message)));
+//            }
         }
 
         [Test]
@@ -84,17 +84,18 @@ namespace Liquid.NET.Tests.Tags
         public void It_Should_Show_Error_On_Missing_Tags()
         {
             // Act
-            try
-            {
-                RenderingHelper.RenderTemplate("Result : {% test %}{% endtest %}");
+            //try
+            //{
+            IList<LiquidError> errors = new List<LiquidError>();
+            RenderingHelper.RenderTemplate("Result : {% test %}{% endtest %}", onRenderingError: errors.Add);
 
-                Assert.Fail("THis should have thrown an error");
-            }
-            catch (LiquidRendererException ex)
-            {
+            //Assert.Fail("THis should have thrown an error");
+            //}
+            //catch (LiquidRendererException ex)
+            //{
                 // Assert
-                Assert.That(String.Join(",", ex.LiquidErrors.Select(x => x.Message)), Is.EqualTo("Liquid syntax error: Unknown tag 'test'"));
-            }
+                Assert.That(String.Join(",",errors.Select(x => x.Message)), Is.EqualTo("Liquid syntax error: Unknown tag 'test'"));
+            //}
         }
 
         [Test]

--- a/Liquid.NET.Tests/Tags/CustomTagTests.cs
+++ b/Liquid.NET.Tests/Tags/CustomTagTests.cs
@@ -35,6 +35,19 @@ namespace Liquid.NET.Tests.Tags
 
         }
 
+        [Test]
+        public void It_Should_Render_An_Error_When_No_Tag()
+        {
+            // Act
+            var templateContext = new TemplateContext();
+            var result = RenderingHelper.RenderTemplate("Result : {% awefawef %}", templateContext);
+            Console.WriteLine(result);
+            // Assert
+            Assert.That(result, Is.StringContaining("Unknown tag 'awefawef'"));
+
+        }
+
+
 
         // ReSharper disable once ClassNeverInstantiated.Global
         public class EchoArgsTagRenderer : ICustomTagRenderer

--- a/Liquid.NET.Tests/Tags/IncludeTagTests.cs
+++ b/Liquid.NET.Tests/Tags/IncludeTagTests.cs
@@ -145,6 +145,33 @@ namespace Liquid.NET.Tests.Tags
 
         }
 
+        [Test]
+        public void It_Should_Accumulate_Errors_When_Include_Contains_Errors()
+        {
+            // Arrange
+            var ctx = CreateContext(new Dictionary<String, String>
+            {
+                { "test", "problem: {{ 1 | divided_by: 0 }}" }
+            }).WithAllFilters();
+            //var defaultAstGenerator = ctx.ASTGenerator;
+            //ctx.WithASTGenerator(str => { called = true; return defaultAstGenerator(str); });
+
+            const String template = "{% include 'test' %}";
+
+            // Act
+
+            var ast = new LiquidASTGenerator().Generate(template);
+            var renderingVisitor = new RenderingVisitor(ctx);
+            String result = "";
+            renderingVisitor.StartWalking(ast.RootNode, x => result += x);
+            Console.WriteLine(result);
+            Assert.That(renderingVisitor.HasErrors);
+
+        }
+
+
+
+
         private static ITemplateContext CreateContext(Dictionary<String, String> dict) 
         {
             return new TemplateContext().WithFileSystem(new TestFileSystem(dict));

--- a/Liquid.NET.Tests/Tags/IncludeTagTests.cs
+++ b/Liquid.NET.Tests/Tags/IncludeTagTests.cs
@@ -36,17 +36,18 @@ namespace Liquid.NET.Tests.Tags
             //ctx.Define("payments", new LiquidCollection(new List<ILiquidValue>()));
 
             const String str = "{% include 'test' %}";
-
+            IList<LiquidError> errors = new List<LiquidError>();
             // Act
-            try
-            {
-                RenderingHelper.RenderTemplate(str, ctx);
-                Assert.Fail("Expected exception");
-            }
-            catch (LiquidParserException ex)
-            {
-                Assert.That(ex.LiquidErrors[0].TokenSource, Is.EqualTo("test"));    
-            }
+            //try
+            //{
+                RenderingHelper.RenderTemplate(str, ctx, errors.Add);
+                //Assert.Fail("Expected exception");
+            //}
+            //catch (LiquidParserException ex)
+            //{
+                //Assert.That(ex.LiquidErrors[0].TokenSource, Is.EqualTo("test"));    
+            Assert.That(errors[0].TokenSource, Is.EqualTo("test"));    
+            //}
             // Assert
             
 
@@ -133,7 +134,7 @@ namespace Liquid.NET.Tests.Tags
                 { "test", "Colour: {{ colour }}, Width: {{ width }}" }
             });
             var defaultAstGenerator = ctx.ASTGenerator;
-            ctx.WithASTGenerator(str => { called = true; return defaultAstGenerator(str); });
+            ctx.WithASTGenerator((str, errFn) => { called = true; return defaultAstGenerator(str, errFn); });
 
             const String tmpl = "{% include 'test' colour: 'Green', width: 10 %}";
 
@@ -146,7 +147,7 @@ namespace Liquid.NET.Tests.Tags
         }
 
         [Test]
-        public void It_Should_Accumulate_Errors_When_Include_Contains_Errors()
+        public void It_Should_Accumulate_Errors_When_Include_Contains_Rendering_Errors()
         {
             // Arrange
             var ctx = CreateContext(new Dictionary<String, String>
@@ -169,6 +170,52 @@ namespace Liquid.NET.Tests.Tags
 
         }
 
+        [Test]
+        public void It_Should_Accumulate_Errors_When_Include_Contains_Parsing_Errors()
+        {
+            // Arrange
+            var ctx = CreateContext(new Dictionary<String, String>
+            {
+                { "test", "problem: {% unterminated" }
+            }).WithAllFilters();
+            //var defaultAstGenerator = ctx.ASTGenerator;
+            //ctx.WithASTGenerator(str => { called = true; return defaultAstGenerator(str); });
+
+            const String template = "{% include 'test' %}";
+
+            // Act
+
+            var ast = new LiquidASTGenerator().Generate(template);
+            var renderingVisitor = new RenderingVisitor(ctx);
+            String result = "";
+            renderingVisitor.StartWalking(ast.RootNode, x => result += x);
+            Console.WriteLine(result);
+            Assert.That(renderingVisitor.HasErrors);
+
+        }
+
+
+        [Test]
+        public void It_Should_Render_An_Error_When_Include_Contains_Parsing_Errors()
+        {
+            // Arrange
+            var ctx = CreateContext(new Dictionary<String, String>
+            {
+                { "test", "problem: {% unterminated" }
+            }).WithAllFilters();
+
+            const String template = "{% include 'test' %}";
+
+            // Act
+
+            var ast = new LiquidASTGenerator().Generate(template);
+            var renderingVisitor = new RenderingVisitor(ctx);
+            String result = "";
+            renderingVisitor.StartWalking(ast.RootNode, x => result += x);
+            Console.WriteLine("RESULT: " + result);
+            Assert.That(result, Is.StringContaining("missing TAGEND"));
+
+        }
 
 
 

--- a/Liquid.NET.Tests/Tags/MacroBlockTagTests.cs
+++ b/Liquid.NET.Tests/Tags/MacroBlockTagTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+
 using Liquid.NET.Constants;
 using NUnit.Framework;
 
@@ -103,19 +103,19 @@ namespace Liquid.NET.Tests.Tags
             var template = LiquidTemplate.Create("Result : {% macro thecycle %}{% cycle 'odd', 'even' %}{% endmacro %}{% for item in array %}{% thecycle %}{% endfor %}");
 
             // Act
-            try
-            {
+//            try
+//            {
                 String result = template.Render(ctx);
                 Logger.Log(result);
 
                 // Assert
                 Assert.That(result.TrimEnd(), Is.EqualTo("Result : oddevenoddeven"));
-            }
-            catch (LiquidRendererException ex)
-            {
-                Logger.Log(ex.Message);
-                throw;
-            }
+//            }
+//            catch (LiquidRendererException ex)
+//            {
+//                Logger.Log(ex.Message);
+//                throw;
+//            }
 
         }
 

--- a/Liquid.NET/src/Constants/LiquidString.cs
+++ b/Liquid.NET/src/Constants/LiquidString.cs
@@ -47,7 +47,7 @@ namespace Liquid.NET.Constants
         /// <returns></returns>
         public LiquidString Join(LiquidString str)
         {
-            return LiquidString.Create(StringVal + str.StringVal);
+            return Create(StringVal + str.StringVal);
         }
 
         public IEnumerator GetEnumerator()

--- a/Liquid.NET/src/Constants/LiquidValue.cs
+++ b/Liquid.NET/src/Constants/LiquidValue.cs
@@ -46,14 +46,7 @@ namespace Liquid.NET.Constants
 
         public static implicit operator Option<ILiquidValue>(LiquidValue t)
         {
-            if (ReferenceEquals(t,null))
-            {
-                return new None<ILiquidValue>();
-            }
-            else
-            {
-                return new Some<ILiquidValue>(t);
-            }
+            return Option<ILiquidValue>.Create(t);
         }
 
         public override bool Equals(object otherObj)

--- a/Liquid.NET/src/Filters/DefaultFilter.cs
+++ b/Liquid.NET/src/Filters/DefaultFilter.cs
@@ -1,4 +1,5 @@
-﻿using Liquid.NET.Constants;
+﻿using System;
+using Liquid.NET.Constants;
 using Liquid.NET.Utils;
 
 namespace Liquid.NET.Filters
@@ -14,47 +15,39 @@ namespace Liquid.NET.Filters
             _defaultValue = defaultValue;
         }
 
-        public override LiquidExpressionResult ApplyTo(ITemplateContext ctx, LiquidString liquidExpression)
-        {
-            if (liquidExpression.StringVal == null || liquidExpression.StringVal.Equals(""))
-            {
-                return CreateDefaultReturn();
-            }
-            else
-            {
-                return LiquidExpressionResult.Success(liquidExpression.ToOption());
-            }
-        }
-
         public override LiquidExpressionResult ApplyTo(ITemplateContext ctx, ILiquidValue liquidExpression)
         {
-            return LiquidExpressionResult.Success(liquidExpression.ToOption());
+            return CreateNonDefaultResult(liquidExpression);
+        }
+
+        public override LiquidExpressionResult ApplyTo(ITemplateContext ctx, LiquidString liquidExpression)
+        {
+            return String.IsNullOrEmpty(liquidExpression.StringVal) ? 
+                CreateDefaultResult() : 
+                CreateNonDefaultResult(liquidExpression);
         }
 
         public override LiquidExpressionResult ApplyTo(ITemplateContext ctx, LiquidCollection liquidCollection)
         {
-            if (liquidCollection != null && liquidCollection.Count > 0)
-            {
-                return LiquidExpressionResult.Success(liquidCollection.ToOption());
-            }
-            else
-            {
-                return CreateDefaultReturn();
-            }
+            return liquidCollection.Count > 0 ?
+                CreateNonDefaultResult(liquidCollection) : 
+                CreateDefaultResult();
         }
-
 
         public override LiquidExpressionResult ApplyToNil(ITemplateContext ctx)
         {
-            return CreateDefaultReturn();
+            return CreateDefaultResult();
         }
 
-        private LiquidExpressionResult CreateDefaultReturn()
+
+        private static LiquidExpressionResult CreateNonDefaultResult(ILiquidValue liquidExpression)
         {
-            Option<ILiquidValue> result = _defaultValue == null
-                ? (Option<ILiquidValue>) new None<ILiquidValue>()
-                : new Some<ILiquidValue>(_defaultValue);
-            return LiquidExpressionResult.Success(result);
+            return LiquidExpressionResult.Success(liquidExpression.ToOption());
+        }
+
+        private LiquidExpressionResult CreateDefaultResult()
+        {
+            return LiquidExpressionResult.Success(Option<ILiquidValue>.Create(_defaultValue));
         }
     }
 }

--- a/Liquid.NET/src/Filters/FilterChain.cs
+++ b/Liquid.NET/src/Filters/FilterChain.cs
@@ -26,17 +26,25 @@ namespace Liquid.NET.Filters
             }
             // create the initial cast for the first value, then a way of unwrapping the value into an Option,
             // then chain with all the other functions.
-            return optionExpression => CreateUnwrapFunction(InitialCast(ctx, expressions.FirstOrDefault()), optionExpression)
-                .Bind(CreateChain(ctx, expressions));
+            return optionExpression =>
+                {
+                    var result = CreateUnwrapFunction(InitialCast(ctx, expressions.FirstOrDefault()), optionExpression).Bind(CreateChain(ctx, expressions));
+                    return result;
+                };
 
         }
 
         private static Func<ILiquidValue, LiquidExpressionResult> InitialCast(
             ITemplateContext ctx, IFilterExpression initialExpression)
         {
-            return expressionConstant => expressionConstant != null
-                ? CreateCastFilter(expressionConstant.GetType(), initialExpression.SourceType).Apply(ctx, expressionConstant)
-                : LiquidExpressionResult.Success(new None<ILiquidValue>());
+            return expressionConstant =>
+            {
+                var result= expressionConstant != null
+                    ? CreateCastFilter(expressionConstant.GetType(), initialExpression.SourceType)
+                        .Apply(ctx, expressionConstant)
+                    : LiquidExpressionResult.Success(new None<ILiquidValue>());
+                return result;
+            };
         }
 
         /// <summary>
@@ -56,7 +64,11 @@ namespace Liquid.NET.Filters
             ITemplateContext ctx,
             IEnumerable<IFilterExpression> filterExpressions)
         {
-            return x => BindAll(ctx, InterpolateCastFilters(filterExpressions))(x);
+            return x =>
+            {
+                var result = BindAll(ctx, InterpolateCastFilters(filterExpressions))(x);
+                return result;
+            };
         }
 
         private static Func<Option<ILiquidValue>, LiquidExpressionResult> BindAll(
@@ -65,7 +77,11 @@ namespace Liquid.NET.Filters
         {
             return initValue => filterExpressions.Aggregate(
                 LiquidExpressionResult.Success(initValue),
-                (current, filter) => filter.BindFilter(ctx, current));
+                (current, filter) =>
+                {
+                    var result = filter.BindFilter(ctx, current);
+                    return result;
+                });
         }
 
         /// <summary>

--- a/Liquid.NET/src/Filters/FilterExpression.cs
+++ b/Liquid.NET/src/Filters/FilterExpression.cs
@@ -28,14 +28,16 @@ namespace Liquid.NET.Filters
 
         public LiquidExpressionResult BindFilter(ITemplateContext ctx, LiquidExpressionResult current)
         {
-            return current.IsError ? current : ApplyValueOrNil(ctx, current);
+            var result = current.IsError ? current : ApplyValueOrNil(ctx, current); // short-circuit if error
+            return result;
         }
 
         private LiquidExpressionResult ApplyValueOrNil(ITemplateContext ctx, LiquidExpressionResult current)
         {
-            return current.SuccessResult.HasValue
+            var result = current.SuccessResult.HasValue
                 ? Apply(ctx, current.SuccessResult.Value)
                 : ApplyToNil(ctx); // pass through nil, because maybe there's e.g. a "default" filter somewhere in the chain.
+            return result;
         }
 
         /* override some or all of these ApplyTo functions */
@@ -135,7 +137,8 @@ namespace Liquid.NET.Filters
 
         public override LiquidExpressionResult Apply(ITemplateContext ctx, ILiquidValue liquidExpression)
         {
-            return Apply(ctx, (TSource)liquidExpression);
+            var result = Apply(ctx, (TSource)liquidExpression);
+            return result;
         }
         
 

--- a/Liquid.NET/src/Filters/Strings/SplitFilter.cs
+++ b/Liquid.NET/src/Filters/Strings/SplitFilter.cs
@@ -17,6 +17,10 @@ namespace Liquid.NET.Filters.Strings
 
         public override LiquidExpressionResult ApplyTo(ITemplateContext ctx, LiquidString liquidLiquidStringExpression)
         {
+            if (_delimiter == null)
+            {
+                return LiquidExpressionResult.Error("Split filter must have a delimiter");
+            }
             var strings = liquidLiquidStringExpression.StringVal.Split(new[] { _delimiter.StringVal }, StringSplitOptions.RemoveEmptyEntries);
             return LiquidExpressionResult.Success(new LiquidCollection(strings.Select(s => LiquidString.Create(s).ToOption()).ToList()));
         }

--- a/Liquid.NET/src/ILiquidASTGenerator.cs
+++ b/Liquid.NET/src/ILiquidASTGenerator.cs
@@ -4,6 +4,6 @@ namespace Liquid.NET
 {
     public interface ILiquidASTGenerator
     {
-        LiquidAST Generate(String template);
+        LiquidAST Generate(String template, Action<LiquidError> onParserError = null);
     }
 }

--- a/Liquid.NET/src/ITemplateContext.cs
+++ b/Liquid.NET/src/ITemplateContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using Liquid.NET.Constants;
 using Liquid.NET.Filters;
 using Liquid.NET.Symbols;
@@ -22,6 +23,7 @@ namespace Liquid.NET
         ITemplateContext WithLocalVariables(IDictionary<String, Option<ILiquidValue>> kv);
         ITemplateContext WithNoForLimit();
         ITemplateContext WithASTGenerator(Func<string, LiquidAST> astGeneratorFunc);
+
 
         IFileSystem FileSystem { get; }
         IDictionary<String, Object> Registers { get; }

--- a/Liquid.NET/src/ITemplateContext.cs
+++ b/Liquid.NET/src/ITemplateContext.cs
@@ -22,7 +22,7 @@ namespace Liquid.NET
         ITemplateContext WithRegisters(IDictionary<String, Object> kv);
         ITemplateContext WithLocalVariables(IDictionary<String, Option<ILiquidValue>> kv);
         ITemplateContext WithNoForLimit();
-        ITemplateContext WithASTGenerator(Func<string, LiquidAST> astGeneratorFunc);
+        ITemplateContext WithASTGenerator(Func<string, Action<LiquidError>, LiquidAST> astGeneratorFunc);
 
 
         IFileSystem FileSystem { get; }
@@ -30,7 +30,7 @@ namespace Liquid.NET
         SymbolTableStack SymbolTableStack { get; }
         LiquidOptions Options { get; }
 
-        Func<string, LiquidAST> ASTGenerator { get; }
-        
+        Func<string, Action<LiquidError>, LiquidAST> ASTGenerator { get; }
+        //bool RenderErrorsInline { get; set; }
     }
 }

--- a/Liquid.NET/src/LiquidASTGenerator.cs
+++ b/Liquid.NET/src/LiquidASTGenerator.cs
@@ -30,7 +30,7 @@ namespace Liquid.NET
         // ReSharper disable once RedundantDefaultMemberInitializer
         private int _level = 0;
 
-        public event OnParsingErrorEventHandler ParsingErrorEventHandler;
+        //public event OnParsingErrorEventHandler ParsingErrorEventHandler;
 
         private BufferedTokenStream _tokenStream;
         private TokenStreamRewriter _tokenStreamRewriter;
@@ -50,8 +50,9 @@ namespace Liquid.NET
         /// </summary>
         private readonly Stack<TreeNode<IASTNode>> _astNodeStack = new Stack<TreeNode<IASTNode>>();
 
-        public LiquidAST Generate(String template)
+        public LiquidAST Generate(String template, Action<LiquidError> onParserError= null)
         {
+            onParserError = onParserError ?? (err => { });
             //Log("Parsing Template \r\n" + template);
 
             //BufferedTokenStream tokenStream
@@ -94,11 +95,20 @@ namespace Liquid.NET
             //parser.AddErrorListener(new DiagnosticErrorListener());
             //parser.Interpreter.PredictionMode = PredictionMode.LlExactAmbigDetection;           
             // END DEBUG 
-            
-            if (LiquidErrors.Any())
+
+            foreach (var err in LiquidErrors)
             {
-                throw new LiquidParserException(LiquidErrors);
+                onParserError(err);
             }
+
+            // TODO: Need to fix the erroring include renderer....
+
+//            if (LiquidErrors.Any())
+//            {
+//                //ParserError
+//               
+//                throw new LiquidParserException(LiquidErrors);
+//            }
 
             return liquidAst;
         }
@@ -106,7 +116,7 @@ namespace Liquid.NET
         private LiquidErrorListener CreateLiquidErrorListener()
         {
             var liquidErrorListener = new LiquidErrorListener();
-            liquidErrorListener.ParsingErrorEventHandler += ParsingErrorEventHandler;
+            //liquidErrorListener.ParsingErrorEventHandler += ParsingErrorEventHandler;
             liquidErrorListener.ParsingErrorEventHandler += ErrorHandler;
             return liquidErrorListener;
         }

--- a/Liquid.NET/src/LiquidExpressionEvaluator.cs
+++ b/Liquid.NET/src/LiquidExpressionEvaluator.cs
@@ -93,8 +93,8 @@ namespace Liquid.NET
 
             // apply the composed function to the object
             
-            return filterChain(objResult.SuccessResult);
-
+            var result= filterChain(objResult.SuccessResult);
+            return result;
         }
 
 

--- a/Liquid.NET/src/LiquidRendererException.cs
+++ b/Liquid.NET/src/LiquidRendererException.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 
 namespace Liquid.NET
 {
-    public class LiquidRendererException : Exception
+    public class LiquidRendererExceptionOLD : Exception
     {
         private readonly IList<LiquidError> _liquidErrors;
 
-        public LiquidRendererException(IList<LiquidError> liquidErrors)
+        public LiquidRendererExceptionOLD(IList<LiquidError> liquidErrors)
         {
             _liquidErrors = liquidErrors;
         }

--- a/Liquid.NET/src/LiquidTemplate.cs
+++ b/Liquid.NET/src/LiquidTemplate.cs
@@ -4,28 +4,8 @@ namespace Liquid.NET
 {
     public class LiquidTemplate
     {
-
+        
         private readonly LiquidAST _liquidAst;
-
-        public LiquidTemplate(LiquidAST liquidAst)
-        {           
-            _liquidAst = liquidAst;
-        }
-
-        public String Render(ITemplateContext ctx)
-        {
-            var result = "";
-
-            var renderingVisitor = new RenderingVisitor(ctx);
-            renderingVisitor.StartWalking(_liquidAst.RootNode, str => result += str);
-
-            if (renderingVisitor.HasErrors)
-            {
-                throw new LiquidRendererException(renderingVisitor.Errors);
-            }
-
-            return result;
-        }
 
         public static LiquidTemplate Create(String template)
         {
@@ -33,5 +13,26 @@ namespace Liquid.NET
             return new LiquidTemplate(liquidAst);
         }
 
+        public LiquidTemplate(LiquidAST liquidAst)
+        {           
+            _liquidAst = liquidAst;
+        }
+
+        public String Render(ITemplateContext ctx, Action<LiquidError> onRenderingError = null)
+        {
+            onRenderingError = onRenderingError ?? (err => { });
+
+            var result = "";
+
+            var renderingVisitor = new RenderingVisitor(ctx);
+
+            renderingVisitor.RenderingErrorEventHandler += (sender, err) => onRenderingError(err);
+
+            renderingVisitor.StartWalking(
+                _liquidAst.RootNode, 
+                str => result += str);
+
+            return result;
+        }
     }
 }

--- a/Liquid.NET/src/TemplateContext.cs
+++ b/Liquid.NET/src/TemplateContext.cs
@@ -21,7 +21,8 @@ namespace Liquid.NET
     /// </summary>
     public class TemplateContext : ITemplateContext
     {
-        
+
+
         public SymbolTableStack SymbolTableStack {get {return _symbolTablestack;}}
         private readonly SymbolTableStack _symbolTablestack = new SymbolTableStack();
         private readonly SymbolTable _globalSymbolTable;

--- a/Liquid.NET/src/TemplateContext.cs
+++ b/Liquid.NET/src/TemplateContext.cs
@@ -30,14 +30,14 @@ namespace Liquid.NET
         public IDictionary<string, object> Registers { get { return _registers;} }
         private IFileSystem _fileSystem;
         private readonly LiquidOptions _options = new LiquidOptions();
-        private Func<string, LiquidAST> _astGeneratorFunc;
+        private Func<string, Action<LiquidError>, LiquidAST> _astGeneratorFunc;
 
         public LiquidOptions Options
         {
             get { return _options; }
         }
 
-        public Func<string, LiquidAST> ASTGenerator
+        public Func<string, Action<LiquidError>, LiquidAST> ASTGenerator
         {
             get { return _astGeneratorFunc; }
         }
@@ -46,7 +46,7 @@ namespace Liquid.NET
         {            
             _globalSymbolTable = new SymbolTable();
             _symbolTablestack.Push(_globalSymbolTable);            
-            _astGeneratorFunc = snippet => new CachingLiquidASTGenerator(new LiquidASTGenerator()).Generate(snippet);
+            _astGeneratorFunc = (snippet,errorfn) => new CachingLiquidASTGenerator(new LiquidASTGenerator()).Generate(snippet, errorfn);
         }        
 
 
@@ -242,7 +242,7 @@ namespace Liquid.NET
         /// </summary>
         /// <param name="astGeneratorFunc"></param>
         /// <returns></returns>
-        public ITemplateContext WithASTGenerator(Func<String, LiquidAST> astGeneratorFunc)
+        public ITemplateContext WithASTGenerator(Func<string, Action<LiquidError>, LiquidAST> astGeneratorFunc)
         {
             if (astGeneratorFunc == null)
             {

--- a/Liquid.NET/src/Utils/LiquidExpressionResult.cs
+++ b/Liquid.NET/src/Utils/LiquidExpressionResult.cs
@@ -96,6 +96,10 @@ namespace Liquid.NET.Utils
         {
             if (f == null) throw new ArgumentNullException("f");
 
+            //var result = f(self.SuccessOption<T>());
+
+            //return result; // er, is this whole bind necessary?
+
             return self.IsError
                 ? self
                 : f(self.SuccessOption<T>());

--- a/Liquid.Ruby/tests.liquid
+++ b/Liquid.Ruby/tests.liquid
@@ -47,30 +47,37 @@ namespace Liquid.NET.Tests.Ruby
 
         {% if exceptions != empty %}[Test]{% for test in exceptions %}
         [TestCase(@"{{test.input}}", @"{{test.assigns}}", @"{{test.expected | remove: 'EXCEPTION: '}}")]{% endfor %}
-        public void It_Should_Generate_An_Exception(String input, String assigns, String expectedMessage) {
-
+        public void It_Should_Generate_An_Exception(String input, String assigns, String expectedMessage) 
+        {
             // Arrange
-            ITemplateContext ctx = new TemplateContext().WithAllFilters();
+            ITemplateContext ctx = new TemplateContext()
+                .WithAllFilters()
+                .WithFileSystem(new TestFileSystem());
+
             foreach (var tuple in DictionaryFactory.CreateStringMapFromJson(assigns))
             {
                 ctx.DefineLocalVariable(tuple.Item1, tuple.Item2);
             }
 
+            var template = LiquidTemplate.Create(input);
+            IList<LiquidError> errors = new List<LiquidError>();
             try
             {
-                var result = RenderingHelper.RenderTemplate(input);
-                Assert.Fail("Expected exception: "+expectedMessage);
+                String result = template.Render(ctx, onRenderingError: errors.Add);
+                Assert.That(errors.Count, Is.EqualTo(1));
+                Assert.That(errors[0].ToString(), Is.StringContaining(expectedMessage));
             }
             catch (LiquidParserException ex)
             {
                 // Assert
                 Assert.That(ex.LiquidErrors[0].ToString(), Is.StringContaining(expectedMessage));
             }
-            catch (LiquidRendererException ex)
-            {
+            //catch (LiquidRendererException ex)
+            //{
                 // Assert
-                Assert.That(ex.LiquidErrors[0].ToString(), Is.StringContaining(expectedMessage));
-            }
+                // Assert.That(ex.LiquidErrors[0].ToString(), Is.StringContaining(expectedMessage));
+                // Assert.That(errors.ToString(), Is.StringContaining(expectedMessage));
+            //}        
         }
         {% endif %}
     }


### PR DESCRIPTION
When generating an AST with LiquidASTGenerator.Generate(), a programmer can pass an onParserError Action to capture the errors.  (Normally a programmer wouldn't do that directly.)

When rendering a template with LiquidTemplate.Render(), the aller can pass an onRenderingError Action which captures errors.

When using the default CachingTemplateParser, it will now avoid caching when there is a template error.  

Errors in includes are reported to the parent renderer, but also rendered inline (by default).  The old behaviour was to throw an exception up to the top.  

closes #44