### PR TITLE
Add new option for Erroring when variable is missing

### DIFF
--- a/Liquid.NET.Tests/Constants/MissingVariableTests.cs
+++ b/Liquid.NET.Tests/Constants/MissingVariableTests.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Linq;
+using Liquid.NET.Constants;
+using Xunit;
+
+namespace Liquid.NET.Tests.Constants
+{
+    public class MissingVariableTests
+    {
+        [Theory]
+        [InlineData("x", "x")]
+        [InlineData("d.x", "x")]
+        [InlineData("d[x]", "x")]
+        [InlineData("a.b.c", "a")]
+        public void It_Should_Display_An_Error_When_Dereferencing_Missing_Variable(String varname, String missingVar)
+        {
+            // Arrange
+
+            ITemplateContext ctx = new TemplateContext()                              
+                .ErrorWhenVariableMissing();
+            ctx.DefineLocalVariable("d", new LiquidHash());
+           
+            // Act
+            var template = LiquidTemplate.Create("Result : {{ " + varname + " }}");
+            var result = template.LiquidTemplate.Render(ctx);
+            Console.WriteLine(result);
+
+            // Assert
+            Assert.Equal("Result : ERROR: " + missingVar + " is undefined", result.Result);
+
+        }
+
+        [Theory]
+        [InlineData("e[1]")]
+        [InlineData("e.first")]
+        [InlineData("e.last")]
+        public void It_Should_Display_An_Error_When_Dereferencing_Empty_Array(String varname)
+        {
+            // Arrange
+            ITemplateContext ctx = new TemplateContext()
+                .ErrorWhenVariableMissing();
+            ctx.DefineLocalVariable("e", new LiquidCollection());
+
+            // Act
+            //var result = RenderingHelper.RenderTemplate("Result : {{ " + varname + " }}", ctx);
+            var template = LiquidTemplate.Create("Result : {{ " + varname + " }}");
+            var result = template.LiquidTemplate.Render(ctx);
+
+            // Assert
+            Assert.Equal("Result : ERROR: cannot dereference empty array", result.Result);
+
+        }
+
+
+
+        [Fact]
+        public void It_Should_Display_Error_When_Dereferencing_Array_With_Non_Int()
+        {
+            // Arrange
+            ITemplateContext ctx = new TemplateContext()
+                .ErrorWhenVariableMissing();
+            ctx.DefineLocalVariable("e", new LiquidCollection());
+
+            // Act
+            var template = LiquidTemplate.Create("Result : {{ e.x }}");
+            var result = template.LiquidTemplate.Render(ctx);
+            //var result = RenderingHelper.RenderTemplate("Result : {{ e.x }}", ctx);
+
+            // Assert
+            Assert.Contains("invalid index: 'x'", result.Result);
+
+        }
+
+        [Fact]
+        public void It_Should_Display_Error_When_Dereferencing_Primitive_With_Index()
+        {
+            // Arrange
+            ITemplateContext ctx = new TemplateContext()
+                .ErrorWhenVariableMissing();
+            ctx.DefineLocalVariable("e", LiquidString.Create("Hello"));
+
+            // Act
+            var template = LiquidTemplate.Create("Result : {{ e.x }}");
+            var result = template.LiquidTemplate.Render(ctx);
+
+            Assert.True(result.HasRenderingErrors);
+            var errorMessage = String.Join(",", result.RenderingErrors.Select(x => x.Message));
+            // Assert
+            Assert.Contains("invalid string index: 'x'", errorMessage);
+
+        }
+
+
+        [Theory]
+        [InlineData("x")]
+        [InlineData("e[1]")]
+        [InlineData("e.x")]
+        [InlineData("d.x")]
+        [InlineData("d[x]")]
+        [InlineData("a.b.c")]
+        public void It_Should_Not_Display_An_Error_When_Dereferencing_Missing_Variable(String varname)
+        {
+            // Arrange
+            Console.WriteLine(varname);
+            ITemplateContext ctx = new TemplateContext()
+                .ErrorWhenValueMissing();
+            ctx.DefineLocalVariable("e", new LiquidCollection());
+            ctx.DefineLocalVariable("d", new LiquidHash());
+
+            // Act
+            var result = RenderingHelper.RenderTemplate("Result : {{ " + varname + " }}", ctx);
+
+            // Assert
+            Assert.Equal("Result : ", result);
+
+        }
+
+
+
+    }
+}

--- a/Liquid.NET/src/Expressions/VariableReference.cs
+++ b/Liquid.NET/src/Expressions/VariableReference.cs
@@ -19,21 +19,9 @@ namespace Liquid.NET.Expressions
         public override LiquidExpressionResult Eval(ITemplateContext templateContext, IEnumerable<Option<ILiquidValue>> childresults)
         {
             var lookupResult= templateContext.SymbolTableStack.Reference(Name);
-            return lookupResult.IsSuccess ? 
-                lookupResult :
-                ErrorOrNone(templateContext, lookupResult);
-        }
-
-        private LiquidExpressionResult ErrorOrNone(ITemplateContext templateContext, LiquidExpressionResult failureResult)
-        {
-            if (templateContext.Options.ErrorWhenValueMissing)
-            {
-                return failureResult;
-            }
-            else
-            {
-                return LiquidExpressionResult.Success(new None<ILiquidValue>());
-            }
+            return lookupResult.IsSuccess 
+                ? (lookupResult.SuccessResult.HasValue ? lookupResult : LiquidExpressionResult.ErrorOrNone(templateContext, Name)) 
+                : LiquidExpressionResult.MissingOrNone(templateContext, Name);
         }
     }
 }

--- a/Liquid.NET/src/ITemplateContext.cs
+++ b/Liquid.NET/src/ITemplateContext.cs
@@ -24,6 +24,8 @@ namespace Liquid.NET
         ITemplateContext WithNoForLimit();
         ITemplateContext WithASTGenerator(Func<string, Action<LiquidError>, LiquidAST> astGeneratorFunc);
 
+        ITemplateContext ErrorWhenValueMissing();
+        ITemplateContext ErrorWhenVariableMissing();
 
         IFileSystem FileSystem { get; }
         IDictionary<String, Object> Registers { get; }

--- a/Liquid.NET/src/TemplateContext.cs
+++ b/Liquid.NET/src/TemplateContext.cs
@@ -263,12 +263,19 @@ namespace Liquid.NET
             _options.ErrorWhenValueMissing = true;
             return this;
         }
+
+        public ITemplateContext ErrorWhenVariableMissing()
+        {
+            _options.ErrorWhenVariableMissing = true;
+            return this;
+        }
     }
 
     public class LiquidOptions
     {
         public bool NoForLimit { get; internal set; }
         public bool ErrorWhenValueMissing { get; set; }
+        public bool ErrorWhenVariableMissing { get; set; }
     }
 
 }

--- a/Liquid.NET/src/Utils/LiquidExpressionResult.cs
+++ b/Liquid.NET/src/Utils/LiquidExpressionResult.cs
@@ -27,6 +27,18 @@ namespace Liquid.NET.Utils
             }
         }
 
+        public static LiquidExpressionResult MissingOrNone(ITemplateContext ctx, String varname)
+        {
+            if (ctx.Options.ErrorWhenVariableMissing)
+            {
+                return Error(SymbolTable.NotFoundError(varname));
+            }
+            else
+            {
+                return Success(new None<ILiquidValue>());
+            }
+        }
+
         public LiquidExpressionResult WhenError(Action<LiquidError> fn)
         {
             if (IsLeft)


### PR DESCRIPTION
Split the erroring so that if the variable doesn't exist, it gives a different error from when the value is undefined. I've added a new option so you can turn either on.

Let me know what you think.
