### PR TITLE
LiquidValueConverter ignores static properties. Fix for #69.

### DIFF
--- a/Liquid.NET.Tests/Utils/LiquidValueConverterTests.cs
+++ b/Liquid.NET.Tests/Utils/LiquidValueConverterTests.cs
@@ -198,6 +198,21 @@ namespace Liquid.NET.Tests.Utils
         }
 
         [Fact]
+        public void It_Should_Ignore_Static_Properties()
+        {
+            ClassWithStaticProperty.StaticField1 = "aaa";
+            var testClass = new ClassWithStaticProperty { Field1 = "bbb" };
+
+            var result = _converter.Convert(testClass);
+            Assert.True(result.HasValue);
+            var objAsHash = (LiquidHash)result.Value;
+
+            Assert.Equal(1, objAsHash.Keys.Count);
+            Assert.True(objAsHash.ContainsKey("field1"));
+            Assert.Equal(LiquidString.Create(testClass.Field1), objAsHash["field1"].Value);
+        }
+
+        [Fact]
         public void It_Should_Convert_A_Nested_Object()
         {
             // Act
@@ -310,5 +325,10 @@ namespace Liquid.NET.Tests.Utils
 
         }
 
+        public class ClassWithStaticProperty
+        {
+            public String Field1 { get; set; }
+            public static String StaticField1 { get; set; }
+        }
     }
 }

--- a/Liquid.NET/src/Utils/LiquidValueConverter.cs
+++ b/Liquid.NET/src/Utils/LiquidValueConverter.cs
@@ -10,6 +10,8 @@ namespace Liquid.NET.Utils
 {
     public class LiquidValueConverter
     {
+        public static readonly BindingFlags PublicInstancePropertiesWithAGetter = BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty;
+
         public Option<ILiquidValue> Convert(Object obj)
         {
             if (ReferenceEquals(obj, null))
@@ -36,7 +38,7 @@ namespace Liquid.NET.Utils
         {
             var newHash = new LiquidHash();
             var kvps = obj.GetType()
-                .GetProperties()
+                .GetProperties(PublicInstancePropertiesWithAGetter)
                 .Where(property => !(property.GetCustomAttributes<LiquidIgnoreAttribute>().Any() 
                      || (property.GetCustomAttributes<LiquidIgnoreIfNullAttribute>().Any() 
                         && ReferenceEquals(property.GetGetMethod().Invoke(obj, null), null))))


### PR DESCRIPTION
This Pull Request changes the behavior of the LiquidValueConverter so that it ignores static properties (only includes public instance properties with a getter).

That changes the observed behavior of the following code:

```csharp
public class ViewModel
{
    public string Title { get; set; }
    public static string OtherData { get; set; }
}

ViewModel.OtherData = "aaa";
var liquid = new ViewModel() { Title = "bbb" }.ToLiquid();
```

The behavior is changed from `liquid` having two properties, both the `Title` and the `OtherData` property to instead only including the `Title` property.

This fixes #69, in case you agree with the issue.